### PR TITLE
feat: load custom type in pgpool

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,9 +1,11 @@
 package wpgx
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/rs/zerolog/log"
 )
@@ -27,6 +29,8 @@ type Config struct {
 	EnablePrometheus bool          `default:"true"`
 	EnableTracing    bool          `default:"true"`
 	AppName          string        `required:"true"`
+
+	BeforeAcquire func(context.Context, *pgx.Conn) bool `ignored:"true"`
 }
 
 func (c *Config) Valid() error {

--- a/pool.go
+++ b/pool.go
@@ -47,6 +47,9 @@ func newRawPgxPool(ctx context.Context, config *Config) (*pgxpool.Pool, error) {
 	pgConfig.MinConns = config.MinConns
 	pgConfig.MaxConnLifetime = config.MaxConnLifetime
 	pgConfig.MaxConnIdleTime = config.MaxConnIdleTime
+	if config.BeforeAcquire != nil {
+		pgConfig.BeforeAcquire = config.BeforeAcquire
+	}
 	return pgxpool.NewWithConfig(ctx, pgConfig)
 }
 

--- a/testsuite/testsuite_test.go
+++ b/testsuite/testsuite_test.go
@@ -155,12 +155,13 @@ func (suite *metaTestSuite) TestInsertQuery() {
 func (suite *metaTestSuite) TestInsertUseGolden() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-
+	tz, err := time.LoadLocation("America/Los_Angeles")
+	suite.Require().NoError(err)
 	exec := suite.Pool.WConn()
 	rst, err := exec.WExec(ctx,
 		"insert_data",
 		"INSERT INTO docs (id, rev, content, created_at, description) VALUES ($1,$2,$3,$4,$5)",
-		33, 666.7777, "hello world", time.Unix(1000, 0), json.RawMessage("{}"))
+		33, 666.7777, "hello world", time.Unix(1000, 0).UTC().In(tz), json.RawMessage("{}"))
 	suite.Nil(err)
 	n := rst.RowsAffected()
 	suite.Equal(int64(1), n)
@@ -256,6 +257,8 @@ func (suite *metaTestSuite) TestCopyFromUseGolden() {
 	defer cancel()
 	exec := suite.Pool.WConn()
 	dumper := &loaderDumper{exec: exec}
+	tz, err := time.LoadLocation("America/Los_Angeles")
+	suite.Require().NoError(err)
 	n, err := exec.WCopyFrom(ctx,
 		"CopyFrom", []string{"docs"},
 		[]string{"id", "rev", "content", "created_at", "description"},
@@ -264,21 +267,21 @@ func (suite *metaTestSuite) TestCopyFromUseGolden() {
 				Id:          1,
 				Rev:         0.1,
 				Content:     "Alice",
-				CreatedAt:   time.Unix(0, 1),
+				CreatedAt:   time.Unix(0, 1).UTC().In(tz),
 				Description: json.RawMessage(`{}`),
 			},
 			{
 				Id:          2,
 				Rev:         0.2,
 				Content:     "Bob",
-				CreatedAt:   time.Unix(100, 0),
+				CreatedAt:   time.Unix(100, 0).UTC().In(tz),
 				Description: json.RawMessage(`[]`),
 			},
 			{
 				Id:          3,
 				Rev:         0.3,
 				Content:     "Chris",
-				CreatedAt:   time.Unix(1000000, 100),
+				CreatedAt:   time.Unix(1000000, 100).UTC().In(tz),
 				Description: json.RawMessage(`{"key":"value"}`),
 			},
 		}})


### PR DESCRIPTION
Custom types such as enums are not automatically recognized in pgx. They need to be loaded for the connection so that pgx can correctly encode and decode them.

This is done by calling the LoadType function on the connection. In the context of a connection pool, this should be done once for each acquired connection.

**Example**
```
INSERT INTO
    public.operation (task_id, tm, dt, op_status)
VALUES
    (
        UNNEST(@task_ids::int8[]),
        UNNEST(@tms::int8[]),
        UNNEST(@dts::date[]),
        UNNEST(@op_statuses::public.op_status[])
    )
ON CONFLICT (task_id,dt,tm) DO NOTHING
RETURNING
    id, task_id;
```
The statement above throws error on execution:
```
failed to encode args[3]: unable to encode []operationrepo.OpStatus{"pending", "running", "completed"} into text format for unknown type (OID 155579): cannot find encode plan
```

The problem is pgx doesn't recognize type OpStatus, and so the type needs to be registered, referring https://github.com/jackc/pgx/issues/1549#issuecomment-1467107173.

This PR solves the problem for pgpool by accepting a self-defined beforeAcquire function in which one can load custom types into acquired conns.
