### PR TITLE
add envvar broken to force use primary to replace a replica

### DIFF
--- a/config.go
+++ b/config.go
@@ -30,6 +30,7 @@ type ReadReplicaConfig struct {
 	// BeforeAcquire is a function that is called before acquiring a connection.
 	BeforeAcquire func(context.Context, *pgx.Conn) bool `ignored:"true"`
 	IsProxy       bool                                  `default:"false"`
+	Broken        bool                                  `default:"false"`
 }
 
 // Config is the configuration for the WPgx.


### PR DESCRIPTION
When a replica is down, you can configure `replica_broken` to quickly redirect all queries originally targeting this replica to the primary instance. Ping (used as health check in most cases) will also ignore this replica.